### PR TITLE
Read-Modify-Write to a register should be once in pinMode()

### DIFF
--- a/cores/arduino/wiring_digital.cpp
+++ b/cores/arduino/wiring_digital.cpp
@@ -86,8 +86,10 @@ void pinMode(pin_size_t pin, PinMode mode)
             break;
     }
 
-    port->CFGLR &= ~(0xf << (p * 4));
-    port->CFGLR |= (pinConfig << (p * 4));
+    uint32_t cfglr_temp = port->CFGLR;
+    cfglr_temp &= ~(0xf << (p * 4));
+    cfglr_temp |= (pinConfig << (p * 4));
+    port->CFGLR = cfglr_temp;
 }
 
 


### PR DESCRIPTION
The original code have read-modify-write accesses "twice" to port->CFGLR in pinMode(), which always causes unnecessarily mode change to ANALOG INPUT MODE before the new pin mode is set.

Original code have a problem that introduces instability in I2C software driver of U8G2 library. This pull request will fix it.